### PR TITLE
Support macFUSE 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 bazil.org/fuse -- Filesystems in Go
 ===================================
 
+This fork has **support for FUSE on Mac**. MacFUSE 4.0.0 and 3.3 (or newer) are supported.
+
+The original project **dropped support** for FUSE on Mac when OSXFUSE stopped being an open source project [bazil/fuse#224](https://github.com/bazil/fuse/issues/224). I respect the maintainers decisions of both projects.
+
+In this fork, the following patches to _remove_ support for OSXFUSE have been dropped:
+
+* [60eaf8](https://github.com/bazil/fuse/commit/60eaf8f021ce00e5c52529cdcba1067e13c1c2c2) - Remove macOS support
+* [eca21f](https://github.com/bazil/fuse/commit/eca21f36f00e04957de26b2e64e21544fa0e0372) - Comment cleanup after macOS support removal
+
+After forking, a patch to introduce support for macFUSE 4 has been made [#1](https://github.com/zegl/fuse/pull/1).
+
+---
+
 `bazil.org/fuse` is a Go library for writing FUSE userspace
 filesystems.
 

--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -1,208 +1,135 @@
 package fuse
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
-	"path"
 	"strconv"
-	"strings"
-	"sync"
 	"syscall"
+	"unsafe"
 )
 
-var (
-	errNoAvail   = errors.New("no available fuse devices")
-	errNotLoaded = errors.New("osxfuse is not loaded")
-)
-
-func loadOSXFUSE(bin string) error {
-	cmd := exec.Command(bin)
-	cmd.Dir = "/"
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	return err
-}
-
-func openOSXFUSEDev(devPrefix string) (*os.File, error) {
-	var f *os.File
-	var err error
-	for i := uint64(0); ; i++ {
-		path := devPrefix + strconv.FormatUint(i, 10)
-		f, err = os.OpenFile(path, os.O_RDWR, 0000)
-		if os.IsNotExist(err) {
-			if i == 0 {
-				// not even the first device was found -> fuse is not loaded
-				return nil, errNotLoaded
-			}
-
-			// we've run out of kernel-provided devices
-			return nil, errNoAvail
+func mount(mountPoint string, conf *mountConfig, ready chan<- struct{}, errp *error) (*os.File, error) {
+	locations := conf.osxfuseLocations
+	if locations == nil {
+		locations = []OSXFUSEPaths{
+			OSXFUSELocationV4,
+			OSXFUSELocationV3,
 		}
+	}
 
-		if err2, ok := err.(*os.PathError); ok && err2.Err == syscall.EBUSY {
-			// try the next one
+	var binLocation string
+	for _, loc := range locations {
+		if _, err := os.Stat(loc.Mount); os.IsNotExist(err) {
+			// try the other locations
 			continue
 		}
-
-		if err != nil {
-			return nil, err
-		}
-		return f, nil
+		binLocation = loc.Mount
+		break
 	}
-}
-
-func handleMountOSXFUSE(helperName string, errCh chan<- error) func(line string) (ignore bool) {
-	var noMountpointPrefix = helperName + `: `
-	const noMountpointSuffix = `: No such file or directory`
-	return func(line string) (ignore bool) {
-		if strings.HasPrefix(line, noMountpointPrefix) && strings.HasSuffix(line, noMountpointSuffix) {
-			// re-extract it from the error message in case some layer
-			// changed the path
-			mountpoint := line[len(noMountpointPrefix) : len(line)-len(noMountpointSuffix)]
-			err := &MountpointDoesNotExistError{
-				Path: mountpoint,
-			}
-			select {
-			case errCh <- err:
-				return true
-			default:
-				// not the first error; fall back to logging it
-				return false
-			}
-		}
-
-		return false
+	if binLocation == "" {
+		return nil, ErrOSXFUSENotFound
 	}
-}
 
-// isBoringMountOSXFUSEError returns whether the Wait error is
-// uninteresting; exit status 64 is.
-func isBoringMountOSXFUSEError(err error) bool {
-	if err, ok := err.(*exec.ExitError); ok && err.Exited() {
-		if status, ok := err.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == 64 {
-			return true
-		}
+	local, remote, err := unixgramSocketpair()
+	if err != nil {
+		return nil, err
 	}
-	return false
-}
 
-func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *os.File, ready chan<- struct{}, errp *error) error {
-	for k, v := range conf.options {
-		if strings.Contains(k, ",") || strings.Contains(v, ",") {
-			// Silly limitation but the mount helper does not
-			// understand any escaping. See TestMountOptionCommaError.
-			return fmt.Errorf("mount options cannot contain commas on darwin: %q=%q", k, v)
-		}
-	}
-	cmd := exec.Command(
-		bin,
+	defer local.Close()
+	defer remote.Close()
+
+	cmd := exec.Command(binLocation,
 		"-o", conf.getOptions(),
+
 		// Tell osxfuse-kext how large our buffer is. It must split
 		// writes larger than this into multiple writes.
 		//
 		// OSXFUSE seems to ignore InitResponse.MaxWrite, and uses
 		// this instead.
 		"-o", "iosize="+strconv.FormatUint(maxWrite, 10),
-		// refers to fd passed in cmd.ExtraFiles
-		"3",
-		dir,
-	)
-	cmd.ExtraFiles = []*os.File{f}
-	cmd.Env = os.Environ()
-	// OSXFUSE <3.3.0
-	cmd.Env = append(cmd.Env, "MOUNT_FUSEFS_CALL_BY_LIB=")
-	// OSXFUSE >=3.3.0
-	cmd.Env = append(cmd.Env, "MOUNT_OSXFUSE_CALL_BY_LIB=")
 
-	daemon := os.Args[0]
-	if daemonVar != "" {
-		cmd.Env = append(cmd.Env, daemonVar+"="+daemon)
+		mountPoint)
+
+	cmd.ExtraFiles = []*os.File{remote} // fd would be (index + 3)
+	cmd.Env = append(os.Environ(),
+		"_FUSE_CALL_BY_LIB=",
+		"_FUSE_DAEMON_PATH="+os.Args[0],
+		"_FUSE_COMMFD=3",
+		"_FUSE_COMMVERS=2",
+		"MOUNT_OSXFUSE_CALL_BY_LIB=",
+		"MOUNT_OSXFUSE_DAEMON_PATH="+os.Args[0])
+
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+
+	if err = cmd.Start(); err != nil {
+		return nil, err
 	}
 
-	stdout, err := cmd.StdoutPipe()
+	fd, err := getConnection(local)
 	if err != nil {
-		return fmt.Errorf("setting up mount_osxfusefs stderr: %v", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("setting up mount_osxfusefs stderr: %v", err)
+		return nil, err
 	}
 
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("mount_osxfusefs: %v", err)
-	}
-	helperErrCh := make(chan error, 1)
 	go func() {
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go lineLogger(&wg, "mount helper output", neverIgnoreLine, stdout)
-		helperName := path.Base(bin)
-		go lineLogger(&wg, "mount helper error", handleMountOSXFUSE(helperName, helperErrCh), stderr)
-		wg.Wait()
+		// wait inside a goroutine or otherwise it would block forever for unknown reasons
 		if err := cmd.Wait(); err != nil {
-			// see if we have a better error to report
-			select {
-			case helperErr := <-helperErrCh:
-				// log the Wait error if it's not what we expected
-				if !isBoringMountOSXFUSEError(err) {
-					log.Printf("mount helper failed: %v", err)
-				}
-				// and now return what we grabbed from stderr as the real
-				// error
-				*errp = helperErr
-				close(ready)
-				return
-			default:
-				// nope, fall back to generic message
-			}
-
-			*errp = fmt.Errorf("mount_osxfusefs: %v", err)
-			close(ready)
-			return
+			err = fmt.Errorf("mount_osxfusefs failed: %v. Stderr: %s, Stdout: %s",
+				err, errOut.String(), out.String())
+			*errp = err
 		}
-
-		*errp = nil
 		close(ready)
 	}()
-	return nil
+
+	dup, err := syscall.Dup(int(fd.Fd()))
+	if err != nil {
+		return nil, err
+	}
+
+	syscall.CloseOnExec(int(fd.Fd()))
+	syscall.CloseOnExec(dup)
+
+	return os.NewFile(uintptr(dup), "macfuse"), err
 }
 
-func mount(dir string, conf *mountConfig, ready chan<- struct{}, errp *error) (*os.File, error) {
-	locations := conf.osxfuseLocations
-	if locations == nil {
-		locations = []OSXFUSEPaths{
-			OSXFUSELocationV3,
-			OSXFUSELocationV2,
-		}
+func unixgramSocketpair() (l, r *os.File, err error) {
+	fd, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, nil, os.NewSyscallError("socketpair",
+			err.(syscall.Errno))
 	}
-	for _, loc := range locations {
-		if _, err := os.Stat(loc.Mount); os.IsNotExist(err) {
-			// try the other locations
-			continue
-		}
+	l = os.NewFile(uintptr(fd[0]), "socketpair-half1")
+	r = os.NewFile(uintptr(fd[1]), "socketpair-half2")
+	return
+}
 
-		f, err := openOSXFUSEDev(loc.DevicePrefix)
-		if err == errNotLoaded {
-			err = loadOSXFUSE(loc.Load)
-			if err != nil {
-				return nil, err
-			}
-			// try again
-			f, err = openOSXFUSEDev(loc.DevicePrefix)
-		}
-		if err != nil {
-			return nil, err
-		}
-		err = callMount(loc.Mount, loc.DaemonVar, dir, conf, f, ready, errp)
-		if err != nil {
-			f.Close()
-			return nil, err
-		}
-		return f, nil
+func getConnection(local *os.File) (*os.File, error) {
+	var data [4]byte
+	control := make([]byte, 4*256)
+
+	// n, oobn, recvflags, from, errno  - todo: error checking.
+	_, oobn, _, _,
+	err := syscall.Recvmsg(
+		int(local.Fd()), data[:], control[:], 0)
+	if err != nil {
+		return nil, err
 	}
-	return nil, ErrOSXFUSENotFound
+
+	message := *(*syscall.Cmsghdr)(unsafe.Pointer(&control[0]))
+	fd := *(*int32)(unsafe.Pointer(uintptr(unsafe.Pointer(&control[0])) + syscall.SizeofCmsghdr))
+
+	if message.Type != syscall.SCM_RIGHTS {
+		return nil, fmt.Errorf("getConnection: recvmsg returned wrong control type: %d", message.Type)
+	}
+	if oobn <= syscall.SizeofCmsghdr {
+		return nil, fmt.Errorf("getConnection: too short control message. Length: %d", oobn)
+	}
+	if fd < 0 {
+		return nil, fmt.Errorf("getConnection: fd < 0: %d", fd)
+	}
+
+	return os.NewFile(uintptr(fd), "macfuse"), nil
 }

--- a/options.go
+++ b/options.go
@@ -233,35 +233,20 @@ func WritebackCache() MountOption {
 	}
 }
 
-// OSXFUSEPaths describes the paths used by an installed OSXFUSE
-// version. See OSXFUSELocationV3 for typical values.
+// OSXFUSEPaths describes the path used by an installed OSXFUSE
+// version. See OSXFUSELocationV4 for typical values.
 type OSXFUSEPaths struct {
-	// Prefix for the device file. At mount time, an incrementing
-	// number is suffixed until a free FUSE device is found.
-	DevicePrefix string
-	// Path of the load helper, used to load the kernel extension if
-	// no device files are found.
-	Load string
-	// Path of the mount helper, used for the actual mount operation.
+	// Path of the mount helper, used for the mount operation
 	Mount string
-	// Environment variable used to pass the path to the executable
-	// calling the mount helper.
-	DaemonVar string
 }
 
 // Default paths for OSXFUSE. See OSXFUSELocations.
 var (
-	OSXFUSELocationV3 = OSXFUSEPaths{
-		DevicePrefix: "/dev/osxfuse",
-		Load:         "/Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse",
-		Mount:        "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse",
-		DaemonVar:    "MOUNT_OSXFUSE_DAEMON_PATH",
+	OSXFUSELocationV4 = OSXFUSEPaths{
+		Mount: "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse",
 	}
-	OSXFUSELocationV2 = OSXFUSEPaths{
-		DevicePrefix: "/dev/osxfuse",
-		Load:         "/Library/Filesystems/osxfusefs.fs/Support/load_osxfusefs",
-		Mount:        "/Library/Filesystems/osxfusefs.fs/Support/mount_osxfusefs",
-		DaemonVar:    "MOUNT_FUSEFS_DAEMON_PATH",
+	OSXFUSELocationV3 = OSXFUSEPaths{
+		Mount: "/Library/Filesystems/osxfuse.fs/Contents/Resources/mount_osxfuse",
 	}
 )
 


### PR DESCRIPTION
This drops support for OSX FUSE < 3.3, as only the 'new' mounting semantic is supported